### PR TITLE
Curation to work with Space Grant deposits

### DIFF
--- a/ldcoolp/config/default.ini
+++ b/ldcoolp/config/default.ini
@@ -56,6 +56,9 @@ log_dir = logs
 # Deposit Agreement(s)
 # Provided as a list of strings (multiple entries if needed)
 survey_id = ['***override***']
+
+survey_shortname = ['Main']
+
 token = ***override***
 dataCenter = uarizona.co1
 

--- a/ldcoolp/config/default.ini
+++ b/ldcoolp/config/default.ini
@@ -71,5 +71,6 @@ generate_url = https://%(dataCenter)s.qualtrics.com/jfe/form/
 # README Qualtrics settings
 readme_survey_id = ***override***
 
-# Corresponding email for custom survey_id (#2)
-# survey_2_email = ***override***
+# Email address associated with custom survey_id (#2)
+# Provided as a list
+# survey_2_email = ['***override***']

--- a/ldcoolp/config/default.ini
+++ b/ldcoolp/config/default.ini
@@ -67,3 +67,6 @@ generate_url = https://%(dataCenter)s.qualtrics.com/jfe/form/
 
 # README Qualtrics settings
 readme_survey_id = ***override***
+
+# Corresponding email for custom survey_id (#2)
+# survey_2_email = ***override***

--- a/ldcoolp/config/default.ini
+++ b/ldcoolp/config/default.ini
@@ -53,7 +53,9 @@ log_dir = logs
 # Qualtrics configuration
 [qualtrics]
 
-survey_id = ***override***
+# Deposit Agreement(s)
+# Provided as a list of strings (multiple entries if needed)
+survey_id = ['***override***']
 token = ***override***
 dataCenter = uarizona.co1
 

--- a/ldcoolp/config/dict_load.py
+++ b/ldcoolp/config/dict_load.py
@@ -1,4 +1,5 @@
 import configparser
+import ast
 
 
 def dict_load(config_file):
@@ -23,6 +24,13 @@ def dict_load(config_file):
             if option_input in ['True', 'False']:
                 config_dict[section][option] = config.getboolean(section, option)
             else:
-                config_dict[section][option] = config.get(section, option)
-
+                config_dict[section][option] = option_input
+                # Re-process if value can be interpreted as a list
+                # (allows for multiple values for key)
+                try:
+                    ast_process = ast.literal_eval(option_input)
+                    if isinstance(ast_process, list):
+                        config_dict[section][option] = ast_process
+                except (ValueError, SyntaxError) as e:
+                    pass
     return config_dict

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -342,6 +342,12 @@ class Qualtrics:
 
         populate_response_dict = dict()  # init
 
+        def _std_populate_response_dict():
+            populate_response_dict['QID4'] = {
+                "1": dn_dict['fullName'],
+                "2": dn_dict['depositor_email']
+            }
+
         use_survey_id = self.survey_id[0]
         if 'survey_2_email' in self.dict:
             # Specific for Space Grant. Q4_1,2,3 is populated through embedded
@@ -355,12 +361,11 @@ class Qualtrics:
             else:
                 use_survey_id = self.survey_id[0]
 
-                populate_response_dict['QID4'] = {
-                    "1": dn_dict['fullName'],
-                    "2": dn_dict['depositor_email']
-                }
+                _std_populate_response_dict()
         else:
             self.log.debug("No survey_2_email settings")
+
+            _std_populate_response_dict()
 
         return use_survey_id, populate_response_dict
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -329,25 +329,29 @@ class Qualtrics:
         populate_response_dict = dict()
 
         use_survey_id = self.survey_id[0]
+        use_survey_shortname = 'Main'  # Default settings
+        if 'survey_shortname' in self.dict:
+            use_survey_shortname = self.dict['survey_shortname'][0]
+
         if 'survey_2_email' in self.dict:
             # Specific for Space Grant. Q4_1,2,3 is populated through embedded
             # data so not needed here
             if dn_dict['depositor_email'] == self.dict['survey_2_email']:
-                self.log.info("Using different deposit agreement")
                 use_survey_id = self.survey_id[1]
+                use_survey_shortname = self.dict['survey_shortname'][1]
 
                 authors = dn_dict['authors']
                 populate_response_dict['QID4'] = {"1": authors[0]}
                 populate_response_dict['QID11'] = {"1": authors[1]}
             else:
-                self.log.info("Using Main survey_id")
-
                 use_survey_id = self.survey_id[0]
 
                 populate_response_dict['QID4'] = {
                     "1": dn_dict['fullName'],
                     "2": dn_dict['depositor_email']
                 }
+
+        self.log.info(f"Using {use_survey_shortname} deposit agreement")
 
         populate_response_dict['QID7'] = dn_dict['title']
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -272,7 +272,7 @@ class Qualtrics:
                 self.log.info("Only one entry found!")
                 self.log.info(f"Survey completed on {response_dict['Date Completed']}")
                 self.log.info(f" ... for {response_dict['Q7']}")
-                return response_dict['ResponseId']
+                return response_dict['ResponseId'], response_dict['SurveyID']
             else:
                 self.log.warn("Multiple entries found")
 
@@ -285,15 +285,19 @@ class Qualtrics:
 
         if isinstance(ResponseId, type(None)):
             try:
-                ResponseId = self.find_deposit_agreement(dn_dict)
+                ResponseId, SurveyId = self.find_deposit_agreement(dn_dict)
                 self.log.info(f"Qualtrics ResponseID : {ResponseId}")
+                self.log.info(f"Qualtrics SurveyID : {SurveyId}")
             except ValueError:
-                self.log.warn("Error with retrieving ResponseId")
+                self.log.warn("Error with retrieving ResponseId and SurveyId")
                 self.log.info("PROMPT: If you wish, you can manually enter ResponseId to retrieve.")
                 ResponseId = input("PROMPT: An EMPTY RETURN will generate a custom Qualtrics link to provide ... ")
                 self.log.info(f"RESPONSE: {ResponseId}")
+                self.log.info("PROMPT: If you wish, you can manually enter SurveyId to retrieve.")
+                SurveyId = input("PROMPT: An EMPTY RETURN will generate a custom Qualtrics link to provide ... ")
+                self.log.info(f"RESPONSE: {SurveyId}")
 
-                if ResponseId == '':
+                if ResponseId == '' or SurveyId == '':
                     custom_url = self.generate_url(dn_dict)
                     self.log.info("CUSTOM URL BELOW : ")
                     self.log.info(custom_url)
@@ -307,7 +311,7 @@ class Qualtrics:
             else:
                 self.log.info("CLI: Not opening a browser!")
 
-            full_url = f"{self.dict['download_url']}?RID={ResponseId}&SID={self.survey_id}"
+            full_url = f"{self.dict['download_url']}?RID={ResponseId}&SID={SurveyId}"
 
             if browser:
                 webbrowser.open(full_url, new=2)

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -278,6 +278,7 @@ class Qualtrics:
         else:
             if response_df.shape[0] == 1:
                 response_dict = df_to_dict_single(response_df)
+                self.pandas_write_buffer(response_df[cols_order])
                 self.log.info("Only one entry found!")
                 self.log.info(f"Survey completed on {response_dict['Date Completed']}")
                 self.log.info(f" ... for {response_dict['Q7']}")

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -343,7 +343,7 @@ class Qualtrics:
         if 'survey_2_email' in self.dict:
             # Specific for Space Grant. Q4_1,2,3 is populated through embedded
             # data so not needed here
-            if dn_dict['depositor_email'] == self.dict['survey_2_email']:
+            if dn_dict['depositor_email'] in self.dict['survey_2_email']:
                 use_survey_id = self.survey_id[1]
 
                 authors = dn_dict['authors']

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -356,6 +356,8 @@ class Qualtrics:
                     "1": dn_dict['fullName'],
                     "2": dn_dict['depositor_email']
                 }
+        else:
+            self.log.debug("No survey_2_email settings")
 
         use_survey_shortname = self.lookup_survey_shortname(use_survey_id)
         self.log.info(f"Using {use_survey_shortname} deposit agreement")

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -220,6 +220,14 @@ class Qualtrics:
                 print(buffer.getvalue(), file=f)
         buffer.close()
 
+    def lookup_survey_shortname(self, lookup_survey_id):
+        """Return survey shortname"""
+        dict0 = dict(zip(self.survey_id, self.dict['survey_shortname']))
+        try:
+            return dict0[lookup_survey_id]
+        except KeyError:
+            self.log.warn("survey_id not found among list")
+
     def find_deposit_agreement(self, dn_dict):
         """Get Response ID based on a match search for depositor name"""
 
@@ -329,16 +337,11 @@ class Qualtrics:
         populate_response_dict = dict()
 
         use_survey_id = self.survey_id[0]
-        use_survey_shortname = 'Main'  # Default settings
-        if 'survey_shortname' in self.dict:
-            use_survey_shortname = self.dict['survey_shortname'][0]
-
         if 'survey_2_email' in self.dict:
             # Specific for Space Grant. Q4_1,2,3 is populated through embedded
             # data so not needed here
             if dn_dict['depositor_email'] == self.dict['survey_2_email']:
                 use_survey_id = self.survey_id[1]
-                use_survey_shortname = self.dict['survey_shortname'][1]
 
                 authors = dn_dict['authors']
                 populate_response_dict['QID4'] = {"1": authors[0]}
@@ -351,6 +354,7 @@ class Qualtrics:
                     "2": dn_dict['depositor_email']
                 }
 
+        use_survey_shortname = self.lookup_survey_shortname(use_survey_id)
         self.log.info(f"Using {use_survey_shortname} deposit agreement")
 
         populate_response_dict['QID7'] = dn_dict['title']

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -323,8 +323,28 @@ class Qualtrics:
         """
 
         populate_response_dict = dict()
-        populate_response_dict['QID4'] = {"1": dn_dict['fullName'],
-                                          "2": dn_dict['depositor_email']}
+
+        use_survey_id = self.survey_id[0]
+        if 'survey_2_email' in self.dict:
+            # Specific for Space Grant. Q4_1,2,3 is populated through embedded
+            # data so not needed here
+            if dn_dict['depositor_email'] == self.dict['survey_2_email']:
+                self.log.info("Using different deposit agreement")
+                use_survey_id = self.survey_id[1]
+
+                authors = dn_dict['authors']
+                populate_response_dict['QID4'] = {"1": authors[0]}
+                populate_response_dict['QID11'] = {"1": authors[1]}
+            else:
+                self.log.info("Using Main survey_id")
+
+                use_survey_id = self.survey_id[0]
+
+                populate_response_dict['QID4'] = {
+                    "1": dn_dict['fullName'],
+                    "2": dn_dict['depositor_email']
+                }
+
         populate_response_dict['QID7'] = dn_dict['title']
 
         json_txt = quote(json.dumps(populate_response_dict), safe=url_safe)
@@ -335,7 +355,7 @@ class Qualtrics:
 
         # q_eed = base64.urlsafe_b64encode(json.dumps(query_str_dict).encode()).decode()
 
-        full_url = f"{self.dict['generate_url']}{self.survey_id}?" + \
+        full_url = f"{self.dict['generate_url']}{use_survey_id}?" + \
                    urlencode(query_str_dict, safe=url_safe, quote_via=quote)
 
         return full_url

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from os.path import join
 import io
 from os import remove
@@ -330,14 +331,16 @@ class Qualtrics:
                 self.log.info("Here's the URL : ")
                 self.log.info(full_url)
 
-    def generate_url(self, dn_dict):
+    def survey_specific(self, dn_dict: dict) -> Tuple[str, dict]:
         """
-        Purpose:
-          Generate URL with Q_PopulateResponse, and article and curation ID
-          query strings based on Figshare metadata
+        Handles survey specifics for Qualtrics Deposit Agreement form
+        Used by generate_url method
+
+        :param dn_dict: DepositorName dictionary
+        :return: survey_id and dict for Qualtrics links
         """
 
-        populate_response_dict = dict()
+        populate_response_dict = dict()  # init
 
         use_survey_id = self.survey_id[0]
         if 'survey_2_email' in self.dict:
@@ -358,6 +361,17 @@ class Qualtrics:
                 }
         else:
             self.log.debug("No survey_2_email settings")
+
+        return use_survey_id, populate_response_dict
+
+    def generate_url(self, dn_dict):
+        """
+        Purpose:
+          Generate URL with Q_PopulateResponse, and article and curation ID
+          query strings based on Figshare metadata
+        """
+
+        use_survey_id, populate_response_dict = self.survey_specific(dn_dict)
 
         use_survey_shortname = self.lookup_survey_shortname(use_survey_id)
         self.log.info(f"Using {use_survey_shortname} deposit agreement")

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -280,6 +280,9 @@ class Qualtrics:
                 self.log.info("Only one entry found!")
                 self.log.info(f"Survey completed on {response_dict['Date Completed']}")
                 self.log.info(f" ... for {response_dict['Q7']}")
+                survey_shortname = \
+                    self.lookup_survey_shortname(response_dict['SurveyID'])
+                self.log.info(f"Survey name: {survey_shortname}")
                 return response_dict['ResponseId'], response_dict['SurveyID']
             else:
                 self.log.warn("Multiple entries found")

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -36,9 +36,9 @@ from ...config import config_default_dict
 url_safe = '/ {},:"?=@%'
 
 # Column order for markdown print-out of Qualtrics table
-cols_order = ['ResponseId', 'Q4_1', 'Q5', 'Q6_1', 'Q7']
+cols_order = ['ResponseId', 'SurveyID', 'Q4_1', 'Q5', 'Q6_1', 'Q7']
 
-readme_cols_order = ['ResponseId', 'article_id', 'curation_id']
+readme_cols_order = ['ResponseId', 'SurveyID', 'article_id', 'curation_id']
 
 readme_custom_content = ['cite', 'summary', 'files', 'materials', 'contrib', 'notes']
 


### PR DESCRIPTION
See #137

List of testing:
- [x] Test stage deposit with Space Grant coordinator account, `get_data_stage`
- [x] Test stage deposit that is not Space Grant coordinator, `get_data_stage`
- [x] Test link generation for Space Grant case, `get_qualtrics_stage`
- [x] Test link generation for non-Space Grant case, `get_qualtrics_stage`
- [x] Test Qualtrics form without `article_id` and `curation_id` (this is most likely how it will look)

For last bullet point, here's the link to copy/paste:

> https://uarizona.co1.qualtrics.com/jfe/form/SV_cuUzPPlCLVbiOGN?Q_PopulateResponse={"QID4": {"1": "Reagen Leimbach", "2": "rleimbach@email.arizona.edu", "3": "Steward Observatory"}, "QID11": {"1": "Chun Ly", "2": "chunly@arizona.edu", "3": "University Libraries"}, "QID7": "Recalibrating Strong-Line Metallicity Diagnostics: Chemical Abundances from Composite Galaxy Spectra"}