### PR TITLE
Feature+Bug: Handling of missing README form response

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Currently, there are two GitHub Action workflows:
 A list of released features and their issue number(s).
 List is sorted from moderate to minor revisions for reach release.
 
+Unreleased:
+ * Handle missing README form responses for simplified curation sets #172
+
 v0.17.0 - v0.17.4:
  * Include Travis CI configuration (disabled see #136) #129
  * Include GitHub Actions for Python CI build and testing #136

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -210,9 +210,9 @@ class Qualtrics:
             merged_df = merged_df.append([temp_df], ignore_index=True)
         return merged_df
 
-    def get_survey_response(self, survey_id: str, ResponseId: str) -> dict:
+    def get_survey_response(self, survey_id: str, ResponseId: str) -> pd.DataFrame:
         """
-        Provide survey response for a given ResponseId from survey_id
+        Return pandas DataFrame for a given ResponseId from survey_id
         """
         qualtrics_df = self.get_survey_responses(survey_id)
         response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -485,8 +485,9 @@ class Qualtrics:
                 self.log.warn("Multiple entries found")
                 raise ValueError
 
-    def retrieve_qualtrics_readme(self, dn_dict=None, ResponseId='', browser=True):
+    def retrieve_qualtrics_readme(self, dn=None, ResponseId='', browser=True):
         """Retrieve response to Qualtrics README form"""
+        dn_dict = dn.name_dict
 
         if ResponseId:
             response_df = self.get_survey_response(self.readme_survey_id, ResponseId)
@@ -504,6 +505,8 @@ class Qualtrics:
                     response_df = self.get_survey_response(self.readme_survey_id, ResponseId)
                 else:
                     response_df = pd.DataFrame()
+                    readme_url = self.generate_readme_url(dn)
+                    self.log.info(f"README URL: {readme_url}")
 
         if response_df.empty:
             self.log.warn("Empty DataFrame")

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -210,6 +210,15 @@ class Qualtrics:
             merged_df = merged_df.append([temp_df], ignore_index=True)
         return merged_df
 
+    def get_survey_response(self, survey_id: str, ResponseId: str) -> dict:
+        """
+        Provide survey response for a given ResponseId from survey_id
+        """
+        qualtrics_df = self.get_survey_responses(survey_id)
+        response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]
+
+        return response_df
+
     def pandas_write_buffer(self, df):
         """Write pandas content via to_markdown() to logfile"""
 
@@ -479,8 +488,7 @@ class Qualtrics:
         """Retrieve response to Qualtrics README form"""
 
         if ResponseId:
-            qualtrics_df = self.get_survey_responses(self.readme_survey_id)
-            response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]
+            response_df = self.get_survey_response(self.readme_survey_id, ResponseId)
         else:
             try:
                 ResponseId, response_df = self.find_qualtrics_readme(dn_dict)
@@ -492,8 +500,7 @@ class Qualtrics:
                 self.log.info(f"RESPONSE: {ResponseId}")
 
                 if ResponseId:
-                    qualtrics_df = self.get_survey_responses(self.readme_survey_id)
-                    response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]
+                    response_df = self.get_survey_response(self.readme_survey_id, ResponseId)
                 else:
                     response_df = pd.DataFrame()
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -215,8 +215,9 @@ class Qualtrics:
         Return pandas DataFrame for a given ResponseId from survey_id
         """
         qualtrics_df = self.get_survey_responses(survey_id)
-        response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]
-
+        response_df = qualtrics_df[(qualtrics_df['ResponseId'] == ResponseId)]
+        if not response_df.empty:
+            self.log.info(f"Match found with {ResponseId}")
         return response_df
 
     def pandas_write_buffer(self, df):

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -475,34 +475,51 @@ class Qualtrics:
                 self.log.warn("Multiple entries found")
                 raise ValueError
 
-    def retrieve_qualtrics_readme(self, dn_dict=None, ResponseId=None, browser=True):
+    def retrieve_qualtrics_readme(self, dn_dict=None, ResponseId='', browser=True):
         """Retrieve response to Qualtrics README form"""
 
-        if isinstance(ResponseId, type(None)):
+        if ResponseId:
+            qualtrics_df = self.get_survey_responses(self.readme_survey_id)
+            response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]
+        else:
             try:
                 ResponseId, response_df = self.find_qualtrics_readme(dn_dict)
                 self.log.info(f"Qualtrics README ResponseID : {ResponseId}")
-
-                qualtrics_dict = df_to_dict_single(response_df[readme_custom_content])
-                for key in qualtrics_dict.keys():
-                    if isinstance(qualtrics_dict[key], float):
-                        qualtrics_dict[key] = str(qualtrics_dict[key])
-
-                # Separate cite, contrib for list style
-                for field in ['cite', 'contrib']:
-                    if qualtrics_dict[field] != 'nan':
-                        qualtrics_dict[field] = qualtrics_dict[field].split('\n')
-
-                # Markdown files, materials
-                for field in ['files', 'materials']:
-                    if qualtrics_dict[field] != 'nan':
-                        if qualtrics_dict[field][0] == "'":
-                            qualtrics_dict[field] = qualtrics_dict[field][1:]
-                            self.log.debug(f"Removing extra single quote in {field} entry")
-
-                return qualtrics_dict
             except ValueError:
                 self.log.warn("Error with retrieving ResponseId")
                 self.log.info("PROMPT: If you wish, you can manually enter ResponseId to retrieve.")
                 ResponseId = input("PROMPT: An EMPTY RETURN will generate a custom Qualtrics link to provide ... ")
                 self.log.info(f"RESPONSE: {ResponseId}")
+
+                if ResponseId:
+                    qualtrics_df = self.get_survey_responses(self.readme_survey_id)
+                    response_df = qualtrics_df[(qualtrics_df['ResponseID'] == ResponseId)]
+                else:
+                    response_df = pd.DataFrame()
+
+        if response_df.empty:
+            self.log.warn("Empty DataFrame")
+            self.log.info("Filling with empty content")
+            qualtrics_dict = {}
+            for field in readme_custom_content:
+                qualtrics_dict[field] = 'nan'
+            qualtrics_dict['references'] = []
+        else:
+            qualtrics_dict = df_to_dict_single(response_df[readme_custom_content])
+            for key in qualtrics_dict.keys():
+                if isinstance(qualtrics_dict[key], float):
+                    qualtrics_dict[key] = str(qualtrics_dict[key])
+
+            # Separate cite, contrib for list style
+            for field in ['cite', 'contrib']:
+                if qualtrics_dict[field] != 'nan':
+                    qualtrics_dict[field] = qualtrics_dict[field].split('\n')
+
+            # Markdown files, materials
+            for field in ['files', 'materials']:
+                if qualtrics_dict[field] != 'nan':
+                    if qualtrics_dict[field][0] == "'":
+                        qualtrics_dict[field] = qualtrics_dict[field][1:]
+                        self.log.debug(f"Removing extra single quote in {field} entry")
+
+        return qualtrics_dict

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -268,7 +268,7 @@ class ReadmeClass:
 
         q = Qualtrics(qualtrics_dict=self.config_dict['qualtrics'], log=self.log)
 
-        readme_dict = q.retrieve_qualtrics_readme(self.dn.name_dict)
+        readme_dict = q.retrieve_qualtrics_readme(self.dn)
 
         return readme_dict
 


### PR DESCRIPTION
See issue #172.

Implemented as a feature for portability.

Testing:
 - [x] Test case when no README form is available. This should have a generic README.txt with basic Figshare metadata
 - [x] Test case when `ResponseId` is provided during the prompt after it attempts to find a survey response. Here it should use the survey for the corresponding `ResponseId` and populate accordingly.