### PR TITLE
hotfix/v0.17.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `0.17.6`.
+You should see that the version is `0.17.7`.
 
 ### Configuration Settings
 
@@ -240,7 +240,7 @@ Currently, there are two GitHub Action workflows:
 A list of released features and their issue number(s).
 List is sorted from moderate to minor revisions for reach release.
 
-v0.17.0 - v0.17.6:
+v0.17.0 - v0.17.7:
  * Include Travis CI configuration (disabled see #136) #129
  * Include GitHub Actions for Python CI build and testing #136
  * Add script for curation folder rename #120

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ v0.17.0 - v0.17.7:
  * Minor: Fix Qualtrics bug with multiple responses #150
  * Minor: Update `bug report` template #169 
  * Bug: Fix handling of period in author list (middle initial, "et al.") for preferred citation #180
+ * Bug: Use manual `ResponseId` for Qualtrics README form for README.txt generation #182
 
 v0.16.0 - v0.16.4:
  * Add `enhancement` template #131

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "0.17.6"
+__version__ = "0.17.7"
 
 co_path = path.dirname(__file__)
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -401,27 +401,31 @@ class Qualtrics:
             try:
                 ResponseId, response_df = self.find_qualtrics_readme(dn_dict)
                 self.log.info(f"Qualtrics README ResponseID : {ResponseId}")
-
-                qualtrics_dict = df_to_dict_single(response_df[readme_custom_content])
-                for key in qualtrics_dict.keys():
-                    if isinstance(qualtrics_dict[key], float):
-                        qualtrics_dict[key] = str(qualtrics_dict[key])
-
-                # Separate cite, contrib for list style
-                for field in ['cite', 'contrib']:
-                    if qualtrics_dict[field] != 'nan':
-                        qualtrics_dict[field] = qualtrics_dict[field].split('\n')
-
-                # Markdown files, materials
-                for field in ['files', 'materials']:
-                    if qualtrics_dict[field] != 'nan':
-                        if qualtrics_dict[field][0] == "'":
-                            qualtrics_dict[field] = qualtrics_dict[field][1:]
-                            self.log.debug(f"Removing extra single quote in {field} entry")
-
-                return qualtrics_dict
             except ValueError:
                 self.log.warn("Error with retrieving ResponseId")
                 self.log.info("PROMPT: If you wish, you can manually enter ResponseId to retrieve.")
                 ResponseId = input("PROMPT: An EMPTY RETURN will generate a custom Qualtrics link to provide ... ")
                 self.log.info(f"RESPONSE: {ResponseId}")
+
+                if ResponseId:
+                    qualtrics_df = self.get_survey_responses(self.readme_survey_id)
+                    response_df = qualtrics_df[qualtrics_df['ResponseId'] == ResponseId]
+
+            qualtrics_dict = df_to_dict_single(response_df[readme_custom_content])
+            for key in qualtrics_dict.keys():
+                if isinstance(qualtrics_dict[key], float):
+                    qualtrics_dict[key] = str(qualtrics_dict[key])
+
+            # Separate cite, contrib for list style
+            for field in ['cite', 'contrib']:
+                if qualtrics_dict[field] != 'nan':
+                    qualtrics_dict[field] = qualtrics_dict[field].split('\n')
+
+            # Markdown files, materials
+            for field in ['files', 'materials']:
+                if qualtrics_dict[field] != 'nan':
+                    if qualtrics_dict[field][0] == "'":
+                        qualtrics_dict[field] = qualtrics_dict[field][1:]
+                        self.log.debug(f"Removing extra single quote in {field} entry")
+
+            return qualtrics_dict

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='v0.17.6',
+    version='v0.17.7',
     packages=['ldcoolp'],
     url='https://github.com/ualibraries/LD_Cool_P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
This fixes #182 to proceed with README.txt generation if a manual response is provided

<!-- Add any linked issue(s) -->
Fixes #182


**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->


**Bump version**

v0.17.6 -> v0.17.7

- [x] README.md, [installation instructions](../../README.md#installation-instructions)
- [x] [`setup.py`](../../setup.py)
- [x] [`ldcoolp/__init__.py`](../../ldcoolp/__init__.py)


*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
- [x] Testing is a needed with a deposit that has more than 1 README form response.