### PR TITLE
Feature: Retrieve Deposit Agreement PDF via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Currently, there are two GitHub Action workflows:
 A list of released features and their issue number(s).
 List is sorted from moderate to minor revisions for reach release.
 
+ * Feature: Retrieve Deposit Agreement PDF via API #187
+
 v0.17.0 - v0.17.7:
  * Include Travis CI configuration (disabled see #136) #129
  * Include GitHub Actions for Python CI build and testing #136

--- a/ldcoolp/config/default.ini
+++ b/ldcoolp/config/default.ini
@@ -66,7 +66,7 @@ dataCenter = uarizona.co1
 download_url = https://%(dataCenter)s.qualtrics.com/Q/Data/Ajax/GetSingleResponseReport
 
 # Base URL for PDF retrieval of Deposit Agreement
-pdf_url = https://%(dataCenter)s.qualtrics.com/WRQualtricsControlPanel/Report.php?NoStatsTables=1&ResponseSummary=True
+# pdf_url = https://%(dataCenter)s.qualtrics.com/WRQualtricsControlPanel/Report.php?NoStatsTables=1&ResponseSummary=True
 
 # Base URL for survey submission
 generate_url = https://%(dataCenter)s.qualtrics.com/jfe/form/

--- a/ldcoolp/config/default.ini
+++ b/ldcoolp/config/default.ini
@@ -65,6 +65,9 @@ dataCenter = uarizona.co1
 # Base URL to retrieve
 download_url = https://%(dataCenter)s.qualtrics.com/Q/Data/Ajax/GetSingleResponseReport
 
+# Base URL for PDF retrieval of Deposit Agreement
+pdf_url = https://%(dataCenter)s.qualtrics.com/WRQualtricsControlPanel/Report.php?NoStatsTables=1&ResponseSummary=True
+
 # Base URL for survey submission
 generate_url = https://%(dataCenter)s.qualtrics.com/jfe/form/
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -18,6 +18,8 @@ import pandas as pd
 import requests
 import json
 from urllib.parse import quote, urlencode
+from urllib.request import urlretrieve
+from urllib.error import HTTPError
 import webbrowser
 
 # Convert single-entry DataFrame to dictionary
@@ -325,6 +327,24 @@ class Qualtrics:
                 self.log.info("CLI: Not opening a browser!")
 
             full_url = f"{self.dict['download_url']}?RID={ResponseId}&SID={SurveyId}"
+
+            # Retrieve PDF via direct URL link
+            pdf_url = 'retrieve'
+            while pdf_url == 'retrieve':
+                pdf_url = input("To retrieve PDF via API, provide PDF URL here. Hit enter to skip : ")
+
+                if not pdf_url:  # Skip PDF retrieval
+                    break
+
+                if 'qualtrics.com' in pdf_url and pdf_url.endswith("format=pdf"):
+                    try:
+                        urlretrieve(pdf_url, f"Deposit_Agreement_{ResponseId}.pdf")
+                        break
+                    except HTTPError:
+                        print("Unable to retrieve PDF")
+                        pdf_url = 'retrieve'
+                else:
+                    pdf_url = 'retrieve'
 
             if browser:
                 webbrowser.open(full_url, new=2)

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -295,7 +295,8 @@ class Qualtrics:
 
                 raise ValueError
 
-    def retrieve_deposit_agreement(self, dn_dict=None, ResponseId=None, browser=True):
+    def retrieve_deposit_agreement(self, dn_dict=None, ResponseId=None, out_path='',
+                                   browser=True):
         """Opens web browser to navigate to a page with Deposit Agreement Form"""
 
         if isinstance(ResponseId, type(None)):
@@ -329,22 +330,27 @@ class Qualtrics:
             full_url = f"{self.dict['download_url']}?RID={ResponseId}&SID={SurveyId}"
 
             # Retrieve PDF via direct URL link
-            pdf_url = 'retrieve'
-            while pdf_url == 'retrieve':
-                pdf_url = input("To retrieve PDF via API, provide PDF URL here. Hit enter to skip : ")
+            if out_path:
+                pdf_url = 'retrieve'
+                while pdf_url == 'retrieve':
+                    pdf_url = input("To retrieve PDF via API, provide PDF URL here. Hit enter to skip : ")
 
-                if not pdf_url:  # Skip PDF retrieval
-                    break
-
-                if 'qualtrics.com' in pdf_url and pdf_url.endswith("format=pdf"):
-                    try:
-                        urlretrieve(pdf_url, f"Deposit_Agreement_{ResponseId}.pdf")
+                    if not pdf_url:  # Skip PDF retrieval
                         break
-                    except HTTPError:
-                        print("Unable to retrieve PDF")
+
+                    if 'qualtrics.com' in pdf_url and pdf_url.endswith("format=pdf"):
+                        self.log.info(f"RESPONSE: {pdf_url}")
+                        try:
+                            out_pdf = join(out_path, 'Deposit_Agreement.pdf')
+                            urlretrieve(pdf_url, out_pdf)
+                            break
+                        except HTTPError:
+                            self.log.warning("Unable to retrieve PDF")
+                            pdf_url = 'retrieve'
+                    else:
                         pdf_url = 'retrieve'
-                else:
-                    pdf_url = 'retrieve'
+            else:
+                self.log.warn("No out_path specified. Skipping PDF retrieval")
 
             if browser:
                 webbrowser.open(full_url, new=2)

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -163,8 +163,17 @@ def workflow(article_id, url_open=False, browser=True, log=None,
         pw.download_report()
 
         # Download Qualtrics deposit agreement form
+        curation_dict = config_dict['curation']
+        out_path = join(
+            curation_dict[curation_dict['parent_dir']],
+            curation_dict['folder_todo'],
+            pw.dn.folderName,
+            curation_dict['folder_ual_rdm'],
+        )
+        log.debug(f"out_path: {out_path}")
         q = Qualtrics(qualtrics_dict=config_dict['qualtrics'], log=log)
-        q.retrieve_deposit_agreement(pw.dn.name_dict, browser=browser)
+        q.retrieve_deposit_agreement(pw.dn.name_dict, out_path=out_path,
+                                     browser=browser)
 
         # Check for README file and create one if it does not exist
         rc = ReadmeClass(pw.dn, log=log, config_dict=config_dict)


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
This feature enable the retrieval of a PDF URL for the Deposit Agreement and saves it in the UAL_DRM folder.
It prompts the user for the URL that is provided in an email. There are a number of checks that it does.
 1. If a response does not consist of a "qualtrics.com" link that ends with "format=pdf" it will prompt again
 2. If a link is provided, it will attempt to retrieve. If successful, that completes the retrieval.
 3. However, if an HTTPError is returned, you are asked to provide a correct link
 4. To skip the PDF retrieval via URL step, provide a carriage return (i.e., empty input) 


<!-- Add any linked issue(s) -->
See #187

Commit history:
 - Add pdf_url to default.ini [ci skip]
 - Add prompt for Qualtrics PDF URL retrieval
 - Add out_path option in retrieve_deposit_agreement
 - main.workflow: Specify out_path for retrieve_deposit_agreement
 - Update README.md changelog


**ToDo List**

<!-- Add any open questions and Pre-Merge TODOs. Use checkboxes. -->
 - [x] Test with deposit
    - [x] Test while loop when junk is provided
    - [x] Test with bad URL (404 error)
    - [x] Test with good URL (200 response)


**Test plan**
<!-- Explain how you tested this feature so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output, screenshots. -->

**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->


*Resources*
<!-- Links to blog posts, StackOverflow, libraries or add-ons used to solve this problem. -->
