### PR TITLE
Retrieve corresponding author from Qualtrics Deposit Agreement for jinja templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `1.0.2`.
+You should see that the version is `1.0.3`.
 
 ### Configuration Settings
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Currently, there are two GitHub Action workflows:
 A list of released features and their issue number(s).
 List is sorted from moderate to minor revisions for reach release.
 
-v1.0.0 - v1.0.2:
+v1.0.0 - v1.0.3:
  * Feature: Handle multiple Qualtrics Deposit Agreement survey,
    including conference-style submissions (e.g., Space Grant, WCCFL)
    #137, #193, #194
@@ -255,6 +255,7 @@ v1.0.0 - v1.0.2:
  * Chore: Refactor code to use `redata-commons` #197
  * Enhancement: Simple script for Qualtrics link generation for WCCFL conference #171
  * Enhancement: Ability to use different README_template.md #195
+ * Feature: Retrieve corresponding author from Qualtrics Deposit Agreement for jinja templating #138
 
 **Note**: Backward incompatibility with config file due to #137
 

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 CODE_NAME = "LD-Cool-P"
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -336,6 +336,12 @@ class Qualtrics:
                     self.log.info(custom_url)
                     ResponseId = None
 
+                if ResponseId != '':
+                    self.da_response_id = ResponseId
+
+                if SurveyId != '':
+                    self.da_survey_id = SurveyId
+
         if not isinstance(ResponseId, type(None)):
             self.da_response_id = ResponseId
 
@@ -573,6 +579,10 @@ class Qualtrics:
         if not self.da_response_id:
             self.log.info("NO METADATA - Retrieving Deposit Agreement metadata")
             self.find_deposit_agreement(dn_dict)
+        else:
+            self.log.info(f"Parsed ResponseId : {self.da_response_id}")
+            self.log.info(f"Parsed SurveyID : {self.da_survey_id}")
+
         DA_response_df = self.get_survey_response(self.da_survey_id, self.da_response_id)
         DA_dict = df_to_dict_single(DA_response_df)
         qualtrics_dict['corr_author_fullname'] = DA_dict['Q6_1']

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -568,4 +568,15 @@ class Qualtrics:
                         qualtrics_dict[field] = qualtrics_dict[field][1:]
                         self.log.debug(f"Removing extra single quote in {field} entry")
 
+        # Retrieve corresponding author info and append
+        self.log.info("Appending Deposit Agreement's Corresponding Author metadata")
+        if not self.da_response_id:
+            self.log.info("NO METADATA - Retrieving Deposit Agreement metadata")
+            self.find_deposit_agreement(dn_dict)
+        DA_response_df = self.get_survey_response(self.da_survey_id, self.da_response_id)
+        DA_dict = df_to_dict_single(DA_response_df)
+        qualtrics_dict['corr_author_fullname'] = DA_dict['Q6_1']
+        qualtrics_dict['corr_author_email'] = DA_dict['Q6_2']
+        qualtrics_dict['corr_author_affil'] = DA_dict['Q6_3']
+
         return qualtrics_dict

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -123,6 +123,10 @@ class Qualtrics:
 
         self.readme_survey_id = self.dict['readme_survey_id']
 
+        # Initialize Deposit Agreement info
+        self.da_response_id: str = ''
+        self.da_survey_id: str = ''
+
         # Logging
         self.file_logging = False
         if isinstance(log, type(None)):
@@ -295,6 +299,8 @@ class Qualtrics:
                 survey_shortname = \
                     self.lookup_survey_shortname(response_dict['SurveyID'])
                 self.log.info(f"Survey name: {survey_shortname}")
+                self.da_response_id = response_dict['ResponseId']
+                self.da_survey_id = response_dict['SurveyID']
                 return response_dict['ResponseId'], response_dict['SurveyID']
             else:
                 self.log.warn("Multiple entries found")
@@ -331,6 +337,8 @@ class Qualtrics:
                     ResponseId = None
 
         if not isinstance(ResponseId, type(None)):
+            self.da_response_id = ResponseId
+
             if browser:
                 self.log.info("Bringing up a window to login to Qualtrics with SSO ....")
                 webbrowser.open('https://qualtrics.arizona.edu', new=2)

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -86,7 +86,7 @@ class ReadmeClass:
     """
 
     def __init__(self, dn, config_dict=config_default_dict, update=False,
-                 log=None):
+                 q: Qualtrics = None, log=None):
         self.config_dict = config_dict
 
         self.dn = dn
@@ -98,6 +98,13 @@ class ReadmeClass:
             self.log = log_stdout()
         else:
             self.log = log
+
+        # Use or initialize Qualtrics object
+        if q:
+            self.q = q
+        else:
+            self.q = Qualtrics(qualtrics_dict=self.config_dict['qualtrics'],
+                               log=self.log)
 
         curation_dict = self.config_dict['curation']
         self.root_directory_main = curation_dict[curation_dict['parent_dir']]
@@ -322,9 +329,7 @@ class ReadmeClass:
         self.log.info("")
         self.log.info("** IDENTIFYING README FORM RESPONSE **")
 
-        q = Qualtrics(qualtrics_dict=self.config_dict['qualtrics'], log=self.log)
-
-        readme_dict = q.retrieve_qualtrics_readme(self.dn)
+        readme_dict = self.q.retrieve_qualtrics_readme(self.dn)
 
         return readme_dict
 

--- a/ldcoolp/curation/inspection/readme/templates/DVC.md
+++ b/ldcoolp/curation/inspection/readme/templates/DVC.md
@@ -14,8 +14,8 @@ Preferred citation (DataCite format):
 {% endif %}
 
 
-Corresponding Author:   
-  {{ figshare_dict.firstname }} {{ figshare_dict.lastname }}, University of Arizona, {{ figshare_dict.email }}
+Corresponding Author:
+  {{ qualtrics_dict.corr_author_fullname }}, {{ qualtrics_dict.corr_author_affil }}, {{ qualtrics_dict.corr_author_email }}
 
 
 License:

--- a/ldcoolp/curation/inspection/readme/templates/Main.md
+++ b/ldcoolp/curation/inspection/readme/templates/Main.md
@@ -14,8 +14,8 @@ Preferred citation (DataCite format):
 {% endif %}
 
 
-Corresponding Author:   
-  {{ figshare_dict.firstname }} {{ figshare_dict.lastname }}, University of Arizona, {{ figshare_dict.email }}
+Corresponding Author:
+  {{ qualtrics_dict.corr_author_fullname }}, {{ qualtrics_dict.corr_author_affil }}, {{ qualtrics_dict.corr_author_email }}
 
 
 License:

--- a/ldcoolp/curation/inspection/readme/templates/Space_Grant.md
+++ b/ldcoolp/curation/inspection/readme/templates/Space_Grant.md
@@ -14,8 +14,8 @@ Preferred citation (DataCite format):
 {% endif %}
 
 
-Corresponding Author:   
-  {{ figshare_dict.firstname }} {{ figshare_dict.lastname }}, University of Arizona, {{ figshare_dict.email }}
+Corresponding Author:
+  {{ qualtrics_dict.corr_author_fullname }}, {{ qualtrics_dict.corr_author_affil }}, {{ qualtrics_dict.corr_author_email }}
 
 
 License:

--- a/ldcoolp/curation/inspection/readme/templates/WCCFL.md
+++ b/ldcoolp/curation/inspection/readme/templates/WCCFL.md
@@ -14,8 +14,8 @@ Preferred citation (DataCite format):
 {% endif %}
 
 
-Corresponding Author:   
-  {{ figshare_dict.firstname }} {{ figshare_dict.lastname }}, University of Arizona, {{ figshare_dict.email }}
+Corresponding Author:
+  {{ qualtrics_dict.corr_author_fullname }}, {{ qualtrics_dict.corr_author_affil }}, {{ qualtrics_dict.corr_author_email }}
 
 
 License:

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -179,7 +179,7 @@ def workflow(article_id, url_open=False, browser=True, log=None,
                                      browser=browser)
 
         # Check for README file and create one if it does not exist
-        rc = ReadmeClass(pw.dn, log=log, config_dict=config_dict)
+        rc = ReadmeClass(pw.dn, log=log, config_dict=config_dict, q=q)
         rc.main()
 
         # Move to next curation stage, 2.UnderReview curation folder

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='v1.0.2',
+    version='v1.0.3',
     packages=['ldcoolp'],
     url='https://github.com/ualibraries/LD_Cool_P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
This allows for using the corresponding author information in the Deposit Agreement Qualtrics response in the README.txt

Note that this is a simple hack by using earlier retrieval of Qualtrics Deposit Agreement metadata. 

<!-- A description of how this PR addresses the feature/enhancement. -->

<!-- Add any linked issue(s) -->
Closes #138


**ToDo List**

<!-- Add any open questions and Pre-Merge TODOs. Use checkboxes. -->
 - [X] Test with Space Grant deposit
 - [x] Test with regular deposit (Use `12385724`). This required a commit for handling manual entries d0d56ff
 - [x] Test with WCCFL deposit


**Test plan**
<!-- Explain how you tested this feature so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output, screenshots. -->

**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->
- [x] Bump version: v1.0.2 -> v1.0.3

*Resources*
<!-- Links to blog posts, StackOverflow, libraries or add-ons used to solve this problem. -->


*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->
