### PR TITLE
Refactor: README construction prompts are in incorrect order

### DIFF
--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -180,14 +180,19 @@ def workflow(article_id, url_open=False, browser=True, log=None,
 
         # Check for README file and create one if it does not exist
         rc = ReadmeClass(pw.dn, log=log, config_dict=config_dict, q=q)
-        rc.main()
+        try:
+            rc.main()
 
-        # Move to next curation stage, 2.UnderReview curation folder
-        if rc.template_source != 'unknown':
-            log.info("PROMPT: Do you wish to move deposit to the next curation stage?")
-            user_response = input("PROMPT: Type 'Yes'/'yes'. Anything else will skip : ")
-            log.info(f"RESPONSE: {user_response}")
-            if user_response.lower() == 'yes':
-                pw.move_to_next()
-            else:
-                print("Skipping move ...")
+            # Move to next curation stage, 2.UnderReview curation folder
+            if rc.template_source != 'unknown':
+                log.info("PROMPT: Do you wish to move deposit to the next curation stage?")
+                user_response = input("PROMPT: Type 'Yes'/'yes'. Anything else will skip : ")
+                log.info(f"RESPONSE: {user_response}")
+                if user_response.lower() == 'yes':
+                    pw.move_to_next()
+                else:
+                    log.info("Skipping move ...")
+        except SystemExit as msg:
+            log.warning(msg)
+            log.info(" > To construct, run the `update_readme` command")
+


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->

<!-- Add any linked issue(s) -->
Fixes #206


**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [ ] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->


**Bump version**

v1.0.5 -> v1.0.6

- [ ] README.md, [installation instructions](../../README.md#installation-instructions)
- [ ] [`setup.py`](../../setup.py)
- [ ] [`ldcoolp/__init__.py`](../../ldcoolp/__init__.py)


*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->


*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
