### PR TITLE
DVC README template not providing correct carriage returns for custom workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `1.0.6`.
+You should see that the version is `1.0.8`.
 
 ### Configuration Settings
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Currently, there are two GitHub Action workflows:
 A list of released features and their issue number(s).
 List is sorted from moderate to minor revisions for reach release.
 
-v1.0.0 - v1.0.6:
+v1.0.0 - v1.0.8:
  * Feature: Handle multiple Qualtrics Deposit Agreement survey,
    including conference-style submissions (e.g., Space Grant, WCCFL)
    #137, #193, #194
@@ -259,6 +259,7 @@ v1.0.0 - v1.0.6:
  * Feature: Strip Figshare Description footer for README.txt #118
  * Bug: Template for DVC has incorrect jinja content #204
  * Refactor: README construction prompts are in incorrect order #206
+ * DVC README template not providing correct carriage returns for custom workflow #209
 
 **Note**: Backward incompatibility with config file due to #137
 

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "1.0.6"
+__version__ = "1.0.8"
 
 CODE_NAME = "LD-Cool-P"
 

--- a/ldcoolp/curation/inspection/readme/templates/DVC.md
+++ b/ldcoolp/curation/inspection/readme/templates/DVC.md
@@ -38,8 +38,7 @@ DOI:
 {% if ( (qualtrics_dict.files != 'nan') or
         (qualtrics_dict.materials != 'nan') or
         (qualtrics_dict.contrib != 'nan') or
-        (qualtrics_dict.notes != 'nan') or
-        (figshare_dict.references != []) ) %}
+        (qualtrics_dict.notes != 'nan') ) %}
 
 
 
@@ -51,8 +50,7 @@ DOI:
 {{ qualtrics_dict.files }}
 {% if ( (qualtrics_dict.materials != 'nan') or
         (qualtrics_dict.contrib != 'nan') or
-        (qualtrics_dict.notes != 'nan') or
-        (figshare_dict.references != []) ) %}
+        (qualtrics_dict.notes != 'nan') ) %}
 
 
 
@@ -64,8 +62,7 @@ DOI:
 
 {{ qualtrics_dict.materials }}
 {% if ( (qualtrics_dict.contrib != 'nan') or
-        (qualtrics_dict.notes != 'nan') or
-        (figshare_dict.references != []) ) %}
+        (qualtrics_dict.notes != 'nan') ) %}
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='v1.0.6',
+    version='v1.0.8',
     packages=['ldcoolp'],
     url='https://github.com/ualibraries/LD_Cool_P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This fixes the issue with extra carriage return.

<!-- Add any linked issue(s) -->
Fixes #209


**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->


**Bump version**

v1.0.6 -> v1.0.8

- [x] README.md, [installation instructions](../../README.md#installation-instructions)
- [x] [`setup.py`](../../setup.py)
- [x] [`ldcoolp/__init__.py`](../../ldcoolp/__init__.py)


*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->

 - Testing was conducted with one deposit that contain reference links and it worked as intended
